### PR TITLE
feat: Add function for runner item/command printing

### DIFF
--- a/src/houdini_package_runner/runners.toml
+++ b/src/houdini_package_runner/runners.toml
@@ -2,7 +2,7 @@
 
 [black]
     [black.item.MenuFile]
-        flags = [
+        command = [
             "--line-length=150",
         ]
 

--- a/src/houdini_package_runner/runners/base.py
+++ b/src/houdini_package_runner/runners/base.py
@@ -1,4 +1,4 @@
-"""Base class implementation for a package runner"""
+"""Base class implementation for a package runner."""
 
 # Future
 from __future__ import annotations

--- a/src/houdini_package_runner/runners/black/runner.py
+++ b/src/houdini_package_runner/runners/black/runner.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, List
 
 # Houdini Package Runner
 import houdini_package_runner.parser
+import houdini_package_runner.runners.utils
 import houdini_package_runner.utils
 from houdini_package_runner.discoverers import package
 from houdini_package_runner.runners.base import HoudiniPackageRunner
@@ -102,7 +103,7 @@ Any unknown args will be passed along to the black command.
         """
         flags = []
 
-        flags.extend(self.config.get_config_data("flags", item, file_path))
+        flags.extend(self.config.get_config_data("command", item, file_path))
 
         flags.extend(self.extra_args)
 
@@ -121,8 +122,11 @@ Any unknown args will be passed along to the black command.
 
         command.append(str(file_path))
 
+        if self.verbose:
+            houdini_package_runner.runners.utils.print_runner_command(item, command)
+
         return houdini_package_runner.utils.execute_subprocess_command(
-            command, verbose=self._verbose
+            command, verbose=self.verbose
         )
 
 

--- a/src/houdini_package_runner/runners/flake8/runner.py
+++ b/src/houdini_package_runner/runners/flake8/runner.py
@@ -144,8 +144,11 @@ Any unknown args will be passed along to the flake8 command.
 
         command.append(str(file_path))
 
+        if self.verbose:
+            houdini_package_runner.runners.utils.print_runner_command(item, command)
+
         return houdini_package_runner.utils.execute_subprocess_command(
-            command, verbose=self._verbose
+            command, verbose=self.verbose
         )
 
 

--- a/src/houdini_package_runner/runners/isort/runner.py
+++ b/src/houdini_package_runner/runners/isort/runner.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 # Houdini Package Runner
 import houdini_package_runner.parser
+import houdini_package_runner.runners.utils
 import houdini_package_runner.utils
 from houdini_package_runner.discoverers import package
 from houdini_package_runner.runners.base import HoudiniPackageRunner
@@ -240,8 +241,11 @@ Any unknown args will be passed along to the isort command.
 
         command.append(str(file_path))
 
+        if self.verbose:
+            houdini_package_runner.runners.utils.print_runner_command(item, command)
+
         return houdini_package_runner.utils.execute_subprocess_command(
-            command, verbose=self._verbose
+            command, verbose=self.verbose
         )
 
 

--- a/src/houdini_package_runner/runners/modernize/runner.py
+++ b/src/houdini_package_runner/runners/modernize/runner.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, List
 
 # Houdini Package Runner
 import houdini_package_runner.parser
+import houdini_package_runner.runners.utils
 import houdini_package_runner.utils
 from houdini_package_runner.discoverers import package
 from houdini_package_runner.runners.base import HoudiniPackageRunner
@@ -115,8 +116,11 @@ Any unknown args will be passed along to the modernize command.
 
         command.append(str(file_path))
 
+        if self.verbose:
+            houdini_package_runner.runners.utils.print_runner_command(item, command)
+
         return houdini_package_runner.utils.execute_subprocess_command(
-            command, verbose=self._verbose
+            command, verbose=self.verbose
         )
 
 

--- a/src/houdini_package_runner/runners/pylint/runner.py
+++ b/src/houdini_package_runner/runners/pylint/runner.py
@@ -14,13 +14,13 @@ from io import StringIO
 from typing import TYPE_CHECKING, List
 
 # Third Party
-import termcolor
 from pylint import lint
 from pylint.reporters.text import ColorizedTextReporter
 
 # Houdini Package Runner
 import houdini_package_runner.config
 import houdini_package_runner.parser
+import houdini_package_runner.runners.utils
 import houdini_package_runner.utils
 from houdini_package_runner.discoverers import package
 from houdini_package_runner.runners.base import HoudiniPackageRunner
@@ -145,17 +145,16 @@ Any unknown args will be passed along to the pylint command.
         if to_disable:
             flags.append(f"--disable={','.join(to_disable)}")
 
+        command = flags + [str(file_path)]
+
         if self.verbose:
-            print(
-                termcolor.colored(str(item), "cyan"),
-                termcolor.colored(" ".join(flags), "magenta"),
+            houdini_package_runner.runners.utils.print_runner_command(
+                item, command, extra="pylint --output-format=colorized "
             )
 
         buf = StringIO()
 
-        result = lint.Run(
-            [str(file_path)] + flags, reporter=ColorizedTextReporter(buf), exit=False
-        )
+        result = lint.Run(command, reporter=ColorizedTextReporter(buf), exit=False)
 
         output = buf.getvalue()
 

--- a/src/houdini_package_runner/runners/utils.py
+++ b/src/houdini_package_runner/runners/utils.py
@@ -1,0 +1,41 @@
+"""Runner related utilities."""
+
+# Future
+from __future__ import annotations
+
+# Standard Library
+from typing import TYPE_CHECKING, List, Optional
+
+# Third Party
+import termcolor
+
+# Imports for type checking.
+if TYPE_CHECKING:
+    from houdini_package_runner.items.base import BaseItem
+
+
+# =============================================================================
+# FUNCTIONS
+# =============================================================================
+
+
+def print_runner_command(
+    item: BaseItem, command: List[str], extra: Optional[str] = None
+) -> None:
+    """Print a runner item and command.
+
+    The item will be output as cyan and the command as magenta, when possible.
+
+    :param item: The item being processed.
+    :param command: The list of command args being executed.
+    :param extra: Optional value to prepend to the command output.
+    :return:
+
+    """
+    if extra is None:
+        extra = ""
+
+    print(
+        termcolor.colored(str(item), "cyan"),
+        termcolor.colored(extra + " ".join(command), "magenta"),
+    )

--- a/tests/runners/flake8/test_runner.py
+++ b/tests/runners/flake8/test_runner.py
@@ -174,15 +174,20 @@ class TestFlake8Runner:
             assert inst._ignored == []
 
     @pytest.mark.parametrize(
-        "has_ignored, has_builtins",
+        "has_ignored, has_builtins, verbose",
         (
-            (True, True),
-            (False, False),
-            (False, False),
+            (True, True, True),
+            (False, False, False),
         ),
     )
-    def test_process_path(self, mocker, init_runner, has_ignored, has_builtins):
+    def test_process_path(
+        self, mocker, init_runner, has_ignored, has_builtins, verbose
+    ):
         """Test Flake8Runner.process_path."""
+        mock_print = mocker.patch(
+            "houdini_package_runner.runners.utils.print_runner_command"
+        )
+
         mock_path = mocker.MagicMock(spec=pathlib.Path)
 
         mock_item = mocker.MagicMock(spec=houdini_package_runner.items.base.BaseItem)
@@ -225,13 +230,11 @@ class TestFlake8Runner:
             extra_args,
         )
 
-        mock_verbose = mocker.MagicMock(spec=bool)
-
         expected_ignored = []
 
         inst = init_runner()
         inst._ignored = []
-        inst._verbose = mock_verbose
+        inst._verbose = verbose
 
         if has_ignored:
             inst._ignored = ["A123"]
@@ -261,7 +264,13 @@ class TestFlake8Runner:
 
         mock_remove.assert_called()
 
-        mock_execute.assert_called_with(expected_args, verbose=mock_verbose)
+        if verbose:
+            mock_print.assert_called_with(mock_item, expected_args)
+
+        else:
+            mock_print.assert_not_called()
+
+        mock_execute.assert_called_with(expected_args, verbose=verbose)
 
 
 def test_main(mocker):

--- a/tests/runners/isort/test_runner.py
+++ b/tests/runners/isort/test_runner.py
@@ -385,11 +385,18 @@ class TestIsortRunner:
             assert not inst._write_back
 
     @pytest.mark.parametrize(
-        "has_config",
-        (True, False),
+        "has_config, verbose",
+        (
+            (True, True),
+            (False, False),
+        ),
     )
-    def test_process_path(self, mocker, init_runner, has_config):
+    def test_process_path(self, mocker, init_runner, has_config, verbose):
         """Test IsortRunner.process_path."""
+        mock_print = mocker.patch(
+            "houdini_package_runner.runners.utils.print_runner_command"
+        )
+
         mock_path = mocker.MagicMock(spec=pathlib.Path)
 
         mock_item = mocker.MagicMock(
@@ -417,10 +424,8 @@ class TestIsortRunner:
             config_file,
         )
 
-        mock_verbose = mocker.MagicMock(spec=bool)
-
         inst = init_runner()
-        inst._verbose = mock_verbose
+        inst._verbose = verbose
 
         inst.process_path(mock_path, mock_item)
 
@@ -431,7 +436,13 @@ class TestIsortRunner:
 
         expected_args.extend(extra_args + [str(mock_path)])
 
-        mock_execute.assert_called_with(expected_args, verbose=mock_verbose)
+        if verbose:
+            mock_print.assert_called_with(mock_item, expected_args)
+
+        else:
+            mock_print.assert_not_called()
+
+        mock_execute.assert_called_with(expected_args, verbose=verbose)
 
 
 def test__find_known_houdini(shared_datadir):

--- a/tests/runners/modernize/test_runner.py
+++ b/tests/runners/modernize/test_runner.py
@@ -132,9 +132,19 @@ class TestModernizeRunner:
 
         assert inst._extra_args == mock_extra_args
 
-    @pytest.mark.parametrize("has_fixers", (True, False))
-    def test_process_path(self, mocker, init_runner, has_fixers):
+    @pytest.mark.parametrize(
+        "has_fixers, verbose",
+        (
+            (True, True),
+            (False, False),
+        ),
+    )
+    def test_process_path(self, mocker, init_runner, has_fixers, verbose):
         """Test ModernizeRunner.process_path."""
+        mock_print = mocker.patch(
+            "houdini_package_runner.runners.utils.print_runner_command"
+        )
+
         mock_path = mocker.MagicMock(spec=pathlib.Path)
 
         mock_config = mocker.MagicMock(
@@ -164,10 +174,8 @@ class TestModernizeRunner:
             extra_args,
         )
 
-        mock_verbose = mocker.MagicMock(spec=bool)
-
         inst = init_runner()
-        inst._verbose = mock_verbose
+        inst._verbose = verbose
 
         inst.process_path(mock_path, mock_item)
 
@@ -181,7 +189,13 @@ class TestModernizeRunner:
             expected_args.insert(5, "import,print")
             expected_args.insert(5, "--nofix")
 
-        mock_execute.assert_called_with(expected_args, verbose=mock_verbose)
+        if verbose:
+            mock_print.assert_called_with(mock_item, expected_args)
+
+        else:
+            mock_print.assert_not_called()
+
+        mock_execute.assert_called_with(expected_args, verbose=verbose)
 
 
 def test_main(mocker):

--- a/tests/runners/pylint/test_runner.py
+++ b/tests/runners/pylint/test_runner.py
@@ -198,10 +198,10 @@ class TestPyLintRunner:
             "houdini_package_runner.runners.pylint.runner.ColorizedTextReporter"
         )
 
-        mock_print = mocker.patch("builtins.print")
+        mock_print = mocker.patch(
+            "houdini_package_runner.runners.utils.print_runner_command"
+        )
         mock_write = mocker.patch("sys.stdout.write")
-
-        mock_colored = mocker.patch("termcolor.colored")
 
         mock_path = mocker.MagicMock(spec=pathlib.Path)
 
@@ -265,9 +265,7 @@ class TestPyLintRunner:
 
         assert result == mock_run.return_value.linter.msg_status
 
-        expected_args = [str(mock_path)]
-        expected_args.extend(extra_args)
-        expected_args.extend(extra_command)
+        expected_args = extra_args + extra_command
 
         assert mock_config.get_config_data.call_count == 3
 
@@ -278,20 +276,15 @@ class TestPyLintRunner:
         if expected_disabled:
             expected_args.append(f"--disable={','.join(expected_disabled)}")
 
+        expected_args.append(str(mock_path))
+
         if verbose:
-            mock_print.assert_has_calls(
-                (
-                    mocker.call(mock_colored.return_value, mock_colored.return_value),
-                    # mocker.call(),
-                )
+            mock_print.assert_called_with(
+                mock_item, expected_args, extra="pylint --output-format=colorized "
             )
 
-            mock_colored.assert_has_calls(
-                (
-                    mocker.call(str(mock_item), "cyan"),
-                    mocker.call(" ".join(expected_args[1:]), "magenta"),
-                )
-            )
+        else:
+            mock_print.assert_not_called()
 
         mock_run.assert_called_with(
             expected_args, reporter=mock_reporter.return_value, exit=False

--- a/tests/runners/test_utils.py
+++ b/tests/runners/test_utils.py
@@ -1,0 +1,50 @@
+"""Test the houdini_package_runner.runners.utils module."""
+
+# =============================================================================
+# IMPORTS
+# =============================================================================
+
+# Third Party
+import pytest
+
+# Houdini Package Runner
+import houdini_package_runner.items.base
+import houdini_package_runner.runners.utils
+
+# =============================================================================
+# TESTS
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "command, extra, expected",
+    (
+        (["--foo", "--bar"], None, "--foo --bar"),
+        (["--foo", "--bar"], "", "--foo --bar"),
+        (["--foo", "--bar"], "extra --stuff ", "extra --stuff --foo --bar"),
+    ),
+)
+def test_print_runner_command(mocker, command, extra, expected):
+    """Test houdini_package_runner.utils.print_runner_command."""
+    mock_print = mocker.patch("builtins.print")
+
+    mock_colored = mocker.patch("termcolor.colored")
+
+    mock_item = mocker.MagicMock(spec=houdini_package_runner.items.base.BaseItem)
+
+    if extra is not None:
+        houdini_package_runner.runners.utils.print_runner_command(
+            mock_item, command, extra=extra
+        )
+
+    else:
+        houdini_package_runner.runners.utils.print_runner_command(mock_item, command)
+
+    mock_print.assert_called_with(mock_colored.return_value, mock_colored.return_value)
+
+    mock_colored.assert_has_calls(
+        (
+            mocker.call(str(mock_item), "cyan"),
+            mocker.call(expected, "magenta"),
+        )
+    )


### PR DESCRIPTION
All runners have been updated to use the new runner command print function and the pylint runner will now output a full command equivalent to the API call.

resolves: #28